### PR TITLE
Audit logging function returns a future/delay containing the result

### DIFF
--- a/test/org/zalando/stups/friboo/zalando_internal/system/audit_logger/http_test.clj
+++ b/test/org/zalando/stups/friboo/zalando_internal/system/audit_logger/http_test.clj
@@ -13,7 +13,7 @@
   (facts "when :api-url is not set, does nothing, but writes a log warning"
     (with-comp [logger-comp (http-logger/map->HTTP {:configuration {}})]
       (fact "does not make HTTP requests"
-        (logger/log logger-comp {}) => anything
+        (deref (logger/log logger-comp {})) => anything
         (provided
           (clojure.tools.logging/log* anything :warn anything ":api-url is not set, not sending Audit Event: [\"{}\"]") => nil
           (oauth2/access-token anything anything) => anything :times 0
@@ -23,13 +23,13 @@
     (with-comp [logger-comp (http-logger/map->HTTP {:configuration {:api-url "http://foo.bar"}
                                                     :tokens        .tokens.})]
       (fact "log function calls clj-http with provided url"
-        (deref (logger/log logger-comp {})) => nil
+        (deref (logger/log logger-comp {})) => .result.
         (provided
           (utils/digest "{}") => "sha256"
           (oauth2/access-token :http-audit-logger .tokens.) => .token.
           (http/put "http://foo.bar/sha256" (contains {:body         "{}"
                                                        :oauth-token  .token.
-                                                       :content-type :json})) => nil))
+                                                       :content-type :json})) => .result.))
       (fact "log logs to stdout if http call fails"
         (deref (logger/log logger-comp {})) => nil
         (provided

--- a/test/org/zalando/stups/friboo/zalando_internal/system/audit_logger/s3_test.clj
+++ b/test/org/zalando/stups/friboo/zalando_internal/system/audit_logger/s3_test.clj
@@ -13,7 +13,7 @@
   (facts "when :s3-bucket is not set, does nothing, but writes a log warning"
     (with-comp [logger-comp (s3-logger/map->S3 {:configuration {}})]
       (fact "does not make S3 API calls"
-        (logger/log logger-comp {}) => anything
+        (deref (logger/log logger-comp {})) => anything
         (provided
           (clojure.tools.logging/log* anything :warn anything
                                       ":s3-bucket is not set, not sending Audit Event: [\"{}\"]") => nil
@@ -22,7 +22,7 @@
   (facts "when :s3-bucket is set, works"
     (with-comp [logger-comp (s3-logger/map->S3 {:configuration {:s3-bucket "foo-bar"}})]
       (fact "log function calls S3 API"
-        (deref (logger/log logger-comp {})) => nil
+        (deref (logger/log logger-comp {})) => .result.
         (provided
           (tf/unparse anything anything) => "/path/to/file/"
           (utils/digest "{}") => "sha256"
@@ -30,7 +30,7 @@
                                 :key          "/path/to/file/sha256"
                                 :metadata     {:content-length 2
                                                :content-type   "application/json"}
-                                :input-stream anything})) => anything))
+                                :input-stream anything})) => .result.))
       (fact "log logs to stdout if S3 API call fails"
         (deref (logger/log logger-comp {})) => nil
         (provided


### PR DESCRIPTION
Either `nil` or result of `http/put` or `s3/put-object`.