### PR TITLE
Move auth.clj into system namespace

### DIFF
--- a/src/org/zalando/stups/friboo/zalando_internal/system/auth.clj
+++ b/src/org/zalando/stups/friboo/zalando_internal/system/auth.clj
@@ -1,4 +1,4 @@
-(ns org.zalando.stups.friboo.zalando-internal.auth
+(ns org.zalando.stups.friboo.zalando-internal.system.auth
   (:require [clj-http.client :as http]
             [org.zalando.stups.friboo.config :refer [require-config]]
             [org.zalando.stups.friboo.zalando-internal.utils :as utils]

--- a/test/org/zalando/stups/friboo/zalando_internal/system/auth_test.clj
+++ b/test/org/zalando/stups/friboo/zalando_internal/system/auth_test.clj
@@ -1,8 +1,8 @@
-(ns org.zalando.stups.friboo.zalando-internal.auth-test
+(ns org.zalando.stups.friboo.zalando-internal.system.auth-test
   (:require
     [clj-http.client :as http]
     [org.zalando.stups.friboo.zalando-internal.test-utils :refer :all]
-    [org.zalando.stups.friboo.zalando-internal.auth :refer :all]
+    [org.zalando.stups.friboo.zalando-internal.system.auth :refer :all]
     [clojure.test :refer :all]
     [midje.sweet :refer :all]))
 

--- a/test/org/zalando/stups/friboo/zalando_internal/system_test.clj
+++ b/test/org/zalando/stups/friboo/zalando_internal/system_test.clj
@@ -8,7 +8,7 @@
             [org.zalando.stups.friboo.system.metrics :as metrics]
             [org.zalando.stups.friboo.system :as system]
             [clj-http.client :as client]
-            [org.zalando.stups.friboo.zalando-internal.auth :as auth]
+            [org.zalando.stups.friboo.zalando-internal.system.auth :as auth]
             [org.zalando.stups.friboo.system.mgmt-http :as mgmt-http]
             [org.zalando.stups.friboo.zalando-internal.system.oauth2 :as oauth2]
             [org.zalando.stups.friboo.zalando-internal.system.audit-logger.http :as audit-http]))


### PR DESCRIPTION
Authorizer is a component, and all components belong inside `system`.

It's a breaking change and will require a small adaption in Essentials.